### PR TITLE
adds mpu6050 code for rpi and fixes errors in drive_command

### DIFF
--- a/command-scripts/drive-command.py
+++ b/command-scripts/drive-command.py
@@ -6,6 +6,7 @@ from Serial import SerialSystem
 import json
 
 port = "/dev/ttyUSB0"
+get_initial_commands_url = "http://192.168.50.243:5000/drive"
 
 def jsonParse(str):
     if(str.count("{") >= 1 and str.count("}") >= 1 ):
@@ -13,8 +14,6 @@ def jsonParse(str):
             return str[str.rfind("{"):str.rfind("}")+1]
         else:
             return str[str.rfind("{", 0, str.rfind("{")):str.rfind("}")+1]
-
-get_initial_commands_url = "http://192.168.50.243:5000/drive"
 
 web_response = requests.get(get_initial_commands_url)
 print("Getting data from: " + web_response.text)

--- a/demos/MPU6050-demo/run.py
+++ b/demos/MPU6050-demo/run.py
@@ -1,0 +1,6 @@
+import sys
+sys.path.append( '../../modules/MPU6050' )
+from MPU6050 import MPU6050
+
+mpu = MPU6050()
+mpu.read_data()

--- a/modules/MPU6050/MPU6050.py
+++ b/modules/MPU6050/MPU6050.py
@@ -1,0 +1,69 @@
+import smbus			#import SMBus module of I2C
+from time import sleep          #import
+
+class MPU6050:
+    def __init__(self):
+        self.PWR_MGMT_1   = 0x6B
+        self.SMPLRT_DIV   = 0x19
+        self.CONFIG       = 0x1A
+        self.GYRO_CONFIG  = 0x1B
+        self.INT_ENABLE   = 0x38
+        self.ACCEL_XOUT_H = 0x3B
+        self.ACCEL_YOUT_H = 0x3D
+        self.ACCEL_ZOUT_H = 0x3F
+        self.GYRO_XOUT_H  = 0x43
+        self.GYRO_YOUT_H  = 0x45
+        self.GYRO_ZOUT_H  = 0x47
+
+        self.Device_Address = 0x68
+        self.bus = smbus.SMBus(1)
+
+
+    def MPU_Init(self):
+        #write to sample rate register
+        self.bus.write_byte_data(self.Device_Address, self.SMPLRT_DIV, 7)
+        #Write to power management register
+        self.bus.write_byte_data(self.Device_Address, self.PWR_MGMT_1, 1)
+        #Write to Configuration register
+        self.bus.write_byte_data(self.Device_Address, self.CONFIG, 0)
+        #Write to Gyro configuration register
+        self.bus.write_byte_data(self.Device_Address, self.GYRO_CONFIG, 24)
+        #Write to interrupt enable register
+        self.bus.write_byte_data(self.Device_Address, self.INT_ENABLE, 1)
+
+    def read_raw_data(self, addr):
+        #Accelero and Gyro value are 16-bit
+            high = self.bus.read_byte_data(self.Device_Address, addr)
+            low = self.bus.read_byte_data(self.Device_Address, addr+1)
+        
+            #concatenate higher and lower value
+            value = ((high << 8) | low)
+            #to get signed value from mpu6050
+            if(value > 32768):
+                    value = value - 65536
+            return value
+
+    def read_data(self):
+        self.MPU_Init()
+
+        while True:
+            #Read Accelerometer raw value
+            acc_x = self.read_raw_data(self.ACCEL_XOUT_H)
+            acc_y = self.read_raw_data(self.ACCEL_YOUT_H)
+            acc_z = self.read_raw_data(self.ACCEL_ZOUT_H)
+            #Read Gyroscope raw value
+            gyro_x = self.read_raw_data(self.GYRO_XOUT_H)
+            gyro_y = self.read_raw_data(self.GYRO_YOUT_H)
+            gyro_z = self.read_raw_data(self.GYRO_ZOUT_H)
+            
+            Ax = acc_x/16384.0
+            Ay = acc_y/16384.0
+            Az = acc_z/16384.0
+            
+            Gx = gyro_x/131.0
+            Gy = gyro_y/131.0
+            Gz = gyro_z/131.0
+            
+
+            print ("Gx=%.2f" %Gx, u'\u00b0'+ "/s", "\tGy=%.2f" %Gy, u'\u00b0'+ "/s", "\tGz=%.2f" %Gz, u'\u00b0'+ "/s", "\tAx=%.2f g" %Ax, "\tAy=%.2f g" %Ay, "\tAz=%.2f g" %Az) 	
+            sleep(1)


### PR DESCRIPTION
Code for the MPU6050. Needed for GPS-guided autonomy to find rover heading