### PR TITLE
Anything ending in 'env' in the proj root will be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@ __pycache__/
 
 .python-version
 
-.env
-.venv
-env/
-venv/
+*env
 ENV/
 env.bak/
 venv.bak/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .python-version
 
 *env
+*.*env
 ENV/
 env.bak/
 venv.bak/


### PR DESCRIPTION
Simplified the .gitignore and made it a bit more flexible